### PR TITLE
Replace Docker Registry dead link with Docker Hub link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,4 @@ Docekr base image creation scripts for the Scientific Linux.
 
 - [Docker container repository for Scientific Linux][this.project_docker_hub_url]
 
-[this.project_docker_hub_url]: https://registry.hub.docker.com/u/ringo/scientific
+[this.project_docker_hub_url]: https://hub.docker.com/r/ringo/scientific


### PR DESCRIPTION
Hi, thank you very much for your great docker image!

I found some dead links to Docker Registry, so I updated them to Docker Hub links.